### PR TITLE
use a conditional import for importing g-analytics

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,18 @@
 import Firebase from 'firebase'
 import _ from 'lodash'
 import updeep from 'updeep'
-import gaTrack from 'google-analytics-js'
 // import _debug from 'debug'
 // const debug = _// debug('firedux')
 
 if (typeof window !== 'undefined') {
   if (!(window.FIREDUX_OPTIONS && window.FIREDUX_OPTIONS.noTrack)) {
-    gaTrack('UA-82065077-1', 'github.com', '/adjohnson916/firedux/src/index.js')
+    gaTrack = import('google-analytics-js').then(gaTrack =>
+      gaTrack(
+        'UA-82065077-1',
+        'github.com',
+        '/adjohnson916/firedux/src/index.js'
+      )
+    );
   }
 }
 


### PR DESCRIPTION
This should make sure that if the option is false, the dependency doesn’t get included.

I’m not 100% sure if this works with your babel setup etc, but it’s worth a try.